### PR TITLE
feat: optimize performance, add batch support

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -1,13 +1,13 @@
 version: 1
 send_anonymous_usage_stats: true
-project_id: "tap-jaffle-shop"
+project_id: tap-jaffle-shop
 default_environment: test
 environments:
 - name: test
 plugins:
   extractors:
-  - name: "tap-jaffle-shop"
-    namespace: "tap_jaffle_shop"
+  - name: tap-jaffle-shop
+    namespace: tap_jaffle_shop
     pip_url: -e .
     capabilities:
     - state
@@ -15,16 +15,30 @@ plugins:
     - discover
     - about
     - stream-maps
-    config:
-      start_date: '2010-01-01T00:00:00Z'
     settings:
-    # TODO: To configure using Meltano, declare settings and their types here:
-    - name: username
-    - name: password
-      kind: password
-    - name: start_date
-      value: '2010-01-01T00:00:00Z'
+    - name: years
+      kind: integer
+    - name: stream_name_prefix
+      kind: string
+    - name: stream_maps
+      kind: object
+    - name: stream_map_config
+      kind: object
+    - name: batch_config
+      kind: object
+    config:
+      batch_config:
+        encoding:
+          format: jsonl
+          compression: gzip
+        storage:
+          root: ./output/temp/
   loaders:
   - name: target-jsonl
     variant: andyh1203
     pip_url: target-jsonl
+  - name: target-duckdb
+    variant: jwills
+    pip_url: target-duckdb~=0.4
+    config:
+      filepath: outdb.duckdb

--- a/meltano.yml
+++ b/meltano.yml
@@ -26,13 +26,14 @@ plugins:
       kind: object
     - name: batch_config
       kind: object
-    config:
-      batch_config:
-        encoding:
-          format: jsonl
-          compression: gzip
-        storage:
-          root: ./output/temp/
+    # Uncomment to enable batch messaging:
+    # config:
+    #   batch_config:
+    #     encoding:
+    #       format: jsonl
+    #       compression: gzip
+    #     storage:
+    #       root: ./output/temp/
   loaders:
   - name: target-jsonl
     variant: andyh1203

--- a/tap_jaffle_shop/client.py
+++ b/tap_jaffle_shop/client.py
@@ -17,6 +17,8 @@ class JaffleShopStream(PandasStream, metaclass=abc.ABCMeta):
     for streams that are built on Pandas data frames.
     """
 
+    batch_size = 100000
+
     def __init__(
         self,
         tap: Tap,

--- a/tap_jaffle_shop/pandas.py
+++ b/tap_jaffle_shop/pandas.py
@@ -28,7 +28,7 @@ class PandasStream(Stream, metaclass=abc.ABCMeta):
                 data to the target. (Optional.)
         """
         self._dataframe: pd.DataFrame | None = None
-        self._schema: dict | None = None
+        self._schema: dict | None = None  # type: ignore # TODO: Fix in SDK upstream
         super().__init__(tap=tap, name=name, schema=None)
 
     @abc.abstractmethod

--- a/tap_jaffle_shop/tap.py
+++ b/tap_jaffle_shop/tap.py
@@ -62,7 +62,7 @@ class TapJaffleShop(Tap):
                     ),
                 ),
             ),
-        )
+        ),
     ).to_dict()
 
     def create_simulation(self):

--- a/tap_jaffle_shop/tap.py
+++ b/tap_jaffle_shop/tap.py
@@ -34,6 +34,35 @@ class TapJaffleShop(Tap):
                 "between schema and table name."
             ),
         ),
+        th.Property(
+            "batch_config",
+            description=(
+                "If provided, specifies the storage and encoding parameters for "
+                "batch messaging to the target."
+            ),
+            wrapped=th.ObjectType(
+                th.Property(
+                    "encoding",
+                    description="Specifies the format and compression of the batch files.",
+                    wrapped=th.ObjectType(
+                        th.Property("format", th.StringType, allowed_values=["jsonl"]),
+                        th.Property(
+                            "compression",
+                            th.StringType,
+                            allowed_values=["gzip", "none"],
+                        ),
+                    ),
+                ),
+                th.Property(
+                    "storage",
+                    description="Defines the storage layer to use when writing batch files",
+                    wrapped=th.ObjectType(
+                        th.Property("root", th.StringType),
+                        th.Property("prefix", th.StringType),
+                    ),
+                ),
+            ),
+        )
     ).to_dict()
 
     def create_simulation(self):

--- a/tap_jaffle_shop/tap.py
+++ b/tap_jaffle_shop/tap.py
@@ -43,7 +43,9 @@ class TapJaffleShop(Tap):
             wrapped=th.ObjectType(
                 th.Property(
                     "encoding",
-                    description="Specifies the format and compression of the batch files.",
+                    description=(
+                        "Specifies the format and compression of the batch files."
+                    ),
                     wrapped=th.ObjectType(
                         th.Property("format", th.StringType, allowed_values=["jsonl"]),
                         th.Property(
@@ -55,7 +57,9 @@ class TapJaffleShop(Tap):
                 ),
                 th.Property(
                     "storage",
-                    description="Defines the storage layer to use when writing batch files",
+                    description=(
+                        "Defines the storage layer to use when writing batch files"
+                    ),
                     wrapped=th.ObjectType(
                         th.Property("root", th.StringType),
                         th.Property("prefix", th.StringType),


### PR DESCRIPTION
This addresses some odd performance profile characteristics:

1. `jafgen` execution alone is approximately 20 seconds.
2. Running tap-jaffle-shop and echoing output to a text file took approximately 2 minutes.
3. Running tap-jaffle-shop in batch mode (as this PR enables) took approximately 20 seconds.

This PR fixes a few things:

- [x] Adds batch support.
- [x] Caches `PandasStream.schema` results internally to reduce runtime per-record performance cost. (Was previously being called twice per record streamed.)
- [x] Bumps batch size to 100000, reducing frequency of batches to 1-per-stream for 1 year of data.
- [x] Properly defines tap properties in `meltano.yml`.
