### PR TITLE
fix: use composite pk for `supplies`

### DIFF
--- a/tap_jaffle_shop/streams.py
+++ b/tap_jaffle_shop/streams.py
@@ -44,4 +44,4 @@ class SuppliesStream(JaffleShopStream):
     """List of Jaffle Shop supplies."""
 
     base_name = "supplies"
-    primary_keys = ["id"]
+    primary_keys = ["id", "sku"]


### PR DESCRIPTION
Found that primary key `id` doesn't match generated data.

Primary key for this table seems to best be composite `id` with `sku`.